### PR TITLE
v0.2 code

### DIFF
--- a/datetime.fifthtry.site/index.ftd
+++ b/datetime.fifthtry.site/index.ftd
@@ -34,7 +34,7 @@ align-content: left
 	
 	\-- record datetime:
 	\integer date:
-	\integer time:	
+	\integer time:
 	-- end: ds.code
 
 -- end: ds.column
@@ -52,25 +52,25 @@ align-content: left
 	-- end: ds.code
 -- end: ds.column
 
--- ds.heading-small: `datetime.to-unix-time-nanos(dt: datetime) -> integer`:
+-- ds.heading-small: `datetime.to-timestamp-nanos(dt: datetime) -> integer`:
 -- ds.column:
 align-content: left
 	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in nanoseconds (UTC). This is useful for precise time calculations or storage.
 	-- ds.code:
 	lang: ftd
 	
-	\-- integer nanos: $datetime.to-unix-time-nanos(dt = $current)
+	\-- integer nanos: $datetime.to-timestamp-nanos(dt = $current)
 	-- end: ds.code
 -- end: ds.column
 
--- ds.heading-small: `datetime.to-unix-time-millis(dt: datetime) -> integer`:
+-- ds.heading-small: `datetime.to-timestamp-millis(dt: datetime) -> integer`:
 -- ds.column:
 align-content: left
 	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in milliseconds (UTC). This is useful for precise time calculations or storage.
 	-- ds.code:
 	lang: ftd
 	
-	\-- integer millis: $datetime.to-unix-time-millis(dt = $current)
+	\-- integer millis: $datetime.to-timestamp-millis(dt = $current)
 	-- end: ds.code
 -- end: ds.column
 
@@ -78,9 +78,9 @@ align-content: left
 -- ds.column:
 align-content: left
 	-- ds.copy-regular:
-	   
+	
 	   Expects a `datetime` record and a `format` string. Returns a formatted string in the user's local timezone.
-	  
+	
 	   The ft parameter can be either of the following:
 	   - datetime:
 	       - E.g: Wednesday 19th March 2025 9:17:36:788 PM
@@ -98,14 +98,14 @@ align-content: left
 -- ds.heading-medium: `Using the package`
 -- ds.column:
 align-content: left
--- ds.copy-regular: To import the package add the following lines to your FASTN.ftd file
--- ds.code:
-	lang: ftd
-
-	\-- fastn.dependency: datetime-v0.fifthtry.site
-	\-- fastn.auto-import: datetime-v0.fifthtry.site as datetime 
--- end: ds.code
--- ds.copy-regular: Checkout a github example of the package at [datetime-example.fifthtry.site](datetime-example.fifthtry.site) and visit the source code at [https://github.com/ayushdeolasee/datetime-v0/tree/main/datetime-example.fifthtry.site](https://github.com/ayushdeolasee/datetime-v0/tree/main/datetime-example.fifthtry.site) site.
+	-- ds.copy-regular: To import the package add the following lines to your FASTN.ftd file
+	-- ds.code:
+	 lang: ftd
+	
+	 \-- fastn.dependency: datetime-v0.fifthtry.site
+	 \-- fastn.auto-import: datetime-v0.fifthtry.site as datetime
+	-- end: ds.code
+	-- ds.copy-regular: Checkout a github example of the package at [datetime-example.fifthtry.site](datetime-example.fifthtry.site) and visit the source code at [https://github.com/ayushdeolasee/datetime-v0/tree/main/datetime-example.fifthtry.site](https://github.com/ayushdeolasee/datetime-v0/tree/main/datetime-example.fifthtry.site) site.
 -- end: ds.column
 -- end: ds.page
 
@@ -116,17 +116,17 @@ js: $assets.files.js.functions.js
 
 fastn_datetime.now(diff)
 
--- integer to-unix-time-nanos(dt):
+-- integer to-timestamp-nanos(dt):
 datetime dt:
 js: $assets.files.js.functions.js
 
-fastn_datetime.to_unixtime_nanos(dt)
+fastn_datetime.to_timestamp_nanos(dt)
 
--- integer to-unix-time-millis(dt):
+-- integer to-timestamp-millis(dt):
 datetime dt:
 js: $assets.files.js.functions.js
 
-fastn_datetime.to_unixtime_millis(dt)
+fastn_datetime.to_timestamp_millis(dt)
 
 -- string fmt(dt, ft):
 datetime dt:

--- a/datetime.fifthtry.site/index.ftd
+++ b/datetime.fifthtry.site/index.ftd
@@ -52,25 +52,25 @@ align-content: left
 	-- end: ds.code
 -- end: ds.column
 
--- ds.heading-small: `datetime.to_unixtime_nanos(dt: datetime) -> integer`:
+-- ds.heading-small: `datetime.to-unix-time-nanos(dt: datetime) -> integer`:
 -- ds.column:
 align-content: left
 	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in nanoseconds (UTC). This is useful for precise time calculations or storage.
 	-- ds.code:
 	lang: ftd
 	
-	\-- integer nanos: $datetime.to_unixtime_nanos(dt = $current)
+	\-- integer nanos: $datetime.to-unix-time-nanos(dt = $current)
 	-- end: ds.code
 -- end: ds.column
 
--- ds.heading-small: `datetime.to_unixtime_millis(dt: datetime) -> integer`:
+-- ds.heading-small: `datetime.to-unix-time-millis(dt: datetime) -> integer`:
 -- ds.column:
 align-content: left
 	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in milliseconds (UTC). This is useful for precise time calculations or storage.
 	-- ds.code:
 	lang: ftd
 	
-	\-- integer millis: $datetime.to_unixtime_millis(dt = $current)
+	\-- integer millis: $datetime.to-unix-time-millis(dt = $current)
 	-- end: ds.code
 -- end: ds.column
 
@@ -116,13 +116,13 @@ js: $assets.files.js.functions.js
 
 fastn_datetime.now(diff)
 
--- integer to-unixtime-nanos(dt):
+-- integer to-unix-time-nanos(dt):
 datetime dt:
 js: $assets.files.js.functions.js
 
 fastn_datetime.to_unixtime_nanos(dt)
 
--- integer to-unixtime-millis(dt):
+-- integer to-unix-time-millis(dt):
 datetime dt:
 js: $assets.files.js.functions.js
 

--- a/datetime.fifthtry.site/index.ftd
+++ b/datetime.fifthtry.site/index.ftd
@@ -22,12 +22,13 @@ margin: $ds.spaces.vertical-gap.medium
 -- ds.heading-medium: `Records`
 margin: $ds.spaces.vertical-gap.medium
 
--- ds.heading-small: datetime
+-- ds.heading-small: `datetime`
 -- ds.column:
 align-content: left
-	-- ds.copy-regular: A datetime record is a record that represents a date and time. The record has the following fields:
-	-- ds.copy-regular: - date: stores the date as an integer in the format YYYYMMDD (e.g., 20250418 for April 18, 2025)
-	-- ds.copy-regular: - time: stores the time as an integer in the format HHMMSSmmmnnnnnnnnn (e.g., 123008817000000000 for 12:30:08.817000000)
+	-- ds.copy-regular: A `datetime` record is a record that represents a date and time. The record has the following fields:
+	-- ds.copy-regular: - `date`: stores the date as an integer in the format YYYYMMDD (e.g., 20250418 for April 18, 2025)
+	-- ds.copy-regular: - `time`: stores the time as an integer in the format HHMMSSmmmnnnnnnnnn (e.g., 123008817000000000 for 12:30:08.817000000)
+	
 	-- ds.code:
 	lang: ftd
 	
@@ -40,10 +41,10 @@ align-content: left
 -- ds.heading-medium: `Functions`
 margin: $ds.spaces.vertical-gap.medium
 
--- ds.heading-small: datetime.now(diff) -> datetime.datetime:
+-- ds.heading-small: `datetime.now(diff) -> datetime.datetime`:
 -- ds.column:
 align-content: left
-	-- ds.copy-regular: Returns a datetime record with the current date and time in UTC. The date is stored as YYYYMMDD and the time as HHMMSSmmmnnnnnnnnn (to nanosecond precision, nanoseconds padded with zeros). Optional parameter `diff` returns the time from now `diff` minutes later.
+	-- ds.copy-regular: Returns a `datetime` record with the current date and time in UTC. The date is stored as YYYYMMDD and the time as HHMMSSmmmnnnnnnnnn (to nanosecond precision, nanoseconds padded with zeros). Optional parameter `diff` returns the time from now `diff` minutes later.
 	-- ds.code:
 	lang: ftd
 	
@@ -51,18 +52,18 @@ align-content: left
 	-- end: ds.code
 -- end: ds.column
 
--- ds.heading-small: datetime.combine(dt: datetime) -> integer:
+-- ds.heading-small: `datetime.to-unixtime(dt: datetime) -> integer`:
 -- ds.column:
 align-content: left
-	-- ds.copy-regular: Combines a datetime record's date and time fields into a single integer representing the Unix epoch in nanoseconds (UTC). This is useful for precise time calculations or storage.
+	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in nanoseconds (UTC). This is useful for precise time calculations or storage.
 	-- ds.code:
 	lang: ftd
 	
-	\-- integer combined: $datetime.combine(dt = $current)
+	\-- integer combined: $datetime.to-unixtime(dt = $current)
 	-- end: ds.code
 -- end: ds.column
 
--- ds.heading-small: datetime.fmt(dt: datetime, ft: string) -> string:
+-- ds.heading-small: `datetime.fmt(dt: datetime, ft: string) -> string`:
 -- ds.column:
 align-content: left
 	-- ds.copy-regular:
@@ -102,17 +103,17 @@ align-content: left
 optional integer diff:
 js: $assets.files.js.functions.js
 
-datetime(diff)
+fastn_datetime.now(diff)
 
--- integer combine(dt):
+-- integer to-unixtime(dt):
 datetime dt:
 js: $assets.files.js.functions.js
 
-constructSingleInt(dt)
+fastn_datetime.to_unixtime(dt)
 
 -- string fmt(dt, ft):
 datetime dt:
 string ft:
 js: $assets.files.js.functions.js
 
-fmt(dt, ft)
+fastn_datetime.fmt(dt, ft)

--- a/datetime.fifthtry.site/index.ftd
+++ b/datetime.fifthtry.site/index.ftd
@@ -1,8 +1,9 @@
 -- record datetime:
-integer dt:
+integer date:
+integer time:
 
--- datetime current: $now()
--- string format-string: $fmt(dt = $current, ft = "datetime")
+-- datetime currentish: $now()
+-- string format-string: $fmt(dt = $currentish, ft = "datetime")
 
 -- ds.page: Datetime package
 margin: $ds.spaces.vertical-gap.zero
@@ -25,13 +26,14 @@ margin: $ds.spaces.vertical-gap.medium
 -- ds.column:
 align-content: left
 	-- ds.copy-regular: A datetime record is a record that represents a date and time. The record has the following fields:
-	-- ds.copy-regular: - dt: stores the datetime value
+	-- ds.copy-regular: - date: stores the date as an integer in the format YYYYMMDD (e.g., 20250418 for April 18, 2025)
+	-- ds.copy-regular: - time: stores the time as an integer in the format HHMMSSmmmnnnnnnnnn (e.g., 123008817000000000 for 12:30:08.817000000)
 	-- ds.code:
 	lang: ftd
 	
 	\-- record datetime:
-	\integer dt:
-	
+	\integer date:
+	\integer time:	
 	-- end: ds.code
 
 -- end: ds.column
@@ -41,7 +43,7 @@ margin: $ds.spaces.vertical-gap.medium
 -- ds.heading-small: datetime.now(diff) -> datetime.datetime:
 -- ds.column:
 align-content: left
-	-- ds.copy-regular: Returns the time as an i64 unix epoch string with nanoseconds precision in the UTC timezone. Optional parameter of `diff` which returns the time from now `diff` minutes later.
+	-- ds.copy-regular: Returns a datetime record with the current date and time in UTC. The date is stored as YYYYMMDD and the time as HHMMSSmmmnnnnnnnnn (to nanosecond precision, nanoseconds padded with zeros). Optional parameter `diff` returns the time from now `diff` minutes later.
 	-- ds.code:
 	lang: ftd
 	
@@ -49,20 +51,30 @@ align-content: left
 	-- end: ds.code
 -- end: ds.column
 
+-- ds.heading-small: datetime.combine(dt: datetime) -> integer:
+-- ds.column:
+align-content: left
+	-- ds.copy-regular: Combines a datetime record's date and time fields into a single integer representing the Unix epoch in nanoseconds (UTC). This is useful for precise time calculations or storage.
+	-- ds.code:
+	lang: ftd
+	
+	\-- integer combined: $datetime.combine(dt = $current)
+	-- end: ds.code
+-- end: ds.column
 
 -- ds.heading-small: datetime.fmt(dt: datetime, ft: string) -> string:
 -- ds.column:
 align-content: left
 	-- ds.copy-regular:
-	
-	   Expects a `datetime` record and a `format` string. Returns a formatted string in the users timezone.
+	   
+	   Expects a `datetime` record and a `format` string. Returns a formatted string in the user's local timezone.
+	  
 	   The ft parameter can be either of the following:
-	
 	   - datetime:
 	       - E.g: Wednesday 19th March 2025 9:17:36:788 PM
 	   - date:
 	       - E.g: Wednesday 19th March 2025
-	   - time
+	   - time:
 	      - E.g: 9:18:46:177 PM
 	-- end: ds.copy-regular
 	-- ds.code:
@@ -91,6 +103,12 @@ optional integer diff:
 js: $assets.files.js.functions.js
 
 datetime(diff)
+
+-- integer combine(dt):
+datetime dt:
+js: $assets.files.js.functions.js
+
+constructSingleInt(dt)
 
 -- string fmt(dt, ft):
 datetime dt:

--- a/datetime.fifthtry.site/index.ftd
+++ b/datetime.fifthtry.site/index.ftd
@@ -44,7 +44,9 @@ margin: $ds.spaces.vertical-gap.medium
 -- ds.heading-small: `datetime.now(diff) -> datetime.datetime`:
 -- ds.column:
 align-content: left
-	-- ds.copy-regular: Returns a `datetime` record with the current date and time in UTC. The date is stored as YYYYMMDD and the time as HHMMSSmmmnnnnnnnnn (to nanosecond precision, nanoseconds padded with zeros). Optional parameter `diff` returns the time from now `diff` minutes later.
+	-- ds.copy-regular:
+	
+	Returns a `datetime` record with the current date and time in UTC. The date is stored as YYYYMMDD and the time as HHMMSSmmmnnnnnnnnn (to nanosecond precision, nanoseconds padded with zeros). Optional parameter `diff` returns the time from now `diff` minutes later.
 	-- ds.code:
 	lang: ftd
 	
@@ -55,7 +57,9 @@ align-content: left
 -- ds.heading-small: `datetime.to-timestamp-nanos(dt: datetime) -> integer`:
 -- ds.column:
 align-content: left
-	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in nanoseconds (UTC). This is useful for precise time calculations or storage.
+	-- ds.copy-regular:
+	
+	Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in nanoseconds (UTC). This is useful for precise time calculations or storage.
 	-- ds.code:
 	lang: ftd
 	
@@ -66,7 +70,9 @@ align-content: left
 -- ds.heading-small: `datetime.to-timestamp-millis(dt: datetime) -> integer`:
 -- ds.column:
 align-content: left
-	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in milliseconds (UTC). This is useful for precise time calculations or storage.
+	-- ds.copy-regular:
+	
+	Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in milliseconds (UTC). This is useful for precise time calculations or storage.
 	-- ds.code:
 	lang: ftd
 	
@@ -105,7 +111,9 @@ align-content: left
 	 \-- fastn.dependency: datetime-v0.fifthtry.site
 	 \-- fastn.auto-import: datetime-v0.fifthtry.site as datetime
 	-- end: ds.code
-	-- ds.copy-regular: Checkout a github example of the package at [datetime-example.fifthtry.site](datetime-example.fifthtry.site) and visit the source code at [https://github.com/ayushdeolasee/datetime-v0/tree/main/datetime-example.fifthtry.site](https://github.com/ayushdeolasee/datetime-v0/tree/main/datetime-example.fifthtry.site) site.
+	-- ds.copy-regular:
+	
+	Checkout a github example of the package at [datetime-example.fifthtry.site](datetime-example.fifthtry.site) and visit the source code at [https://github.com/ayushdeolasee/datetime-v0/tree/main/datetime-example.fifthtry.site](https://github.com/ayushdeolasee/datetime-v0/tree/main/datetime-example.fifthtry.site) site.
 -- end: ds.column
 -- end: ds.page
 

--- a/datetime.fifthtry.site/index.ftd
+++ b/datetime.fifthtry.site/index.ftd
@@ -52,14 +52,25 @@ align-content: left
 	-- end: ds.code
 -- end: ds.column
 
--- ds.heading-small: `datetime.to-unixtime(dt: datetime) -> integer`:
+-- ds.heading-small: `datetime.to_unixtime_nanos(dt: datetime) -> integer`:
 -- ds.column:
 align-content: left
 	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in nanoseconds (UTC). This is useful for precise time calculations or storage.
 	-- ds.code:
 	lang: ftd
 	
-	\-- integer combined: $datetime.to-unixtime(dt = $current)
+	\-- integer nanos: $datetime.to_unixtime_nanos(dt = $current)
+	-- end: ds.code
+-- end: ds.column
+
+-- ds.heading-small: `datetime.to_unixtime_millis(dt: datetime) -> integer`:
+-- ds.column:
+align-content: left
+	-- ds.copy-regular: Combines a `datetime` record's date and time fields into a single integer representing the Unix epoch in milliseconds (UTC). This is useful for precise time calculations or storage.
+	-- ds.code:
+	lang: ftd
+	
+	\-- integer millis: $datetime.to_unixtime_millis(dt = $current)
 	-- end: ds.code
 -- end: ds.column
 
@@ -105,11 +116,17 @@ js: $assets.files.js.functions.js
 
 fastn_datetime.now(diff)
 
--- integer to-unixtime(dt):
+-- integer to-unixtime-nanos(dt):
 datetime dt:
 js: $assets.files.js.functions.js
 
-fastn_datetime.to_unixtime(dt)
+fastn_datetime.to_unixtime_nanos(dt)
+
+-- integer to-unixtime-millis(dt):
+datetime dt:
+js: $assets.files.js.functions.js
+
+fastn_datetime.to_unixtime_millis(dt)
 
 -- string fmt(dt, ft):
 datetime dt:

--- a/datetime.fifthtry.site/js/functions.js
+++ b/datetime.fifthtry.site/js/functions.js
@@ -29,7 +29,7 @@
         });
     }
 
-    function to_unixtime(dt) {
+    function to_unixtime_nanos(dt) {
         const { date, time } = dt.get().toObject();
         // Parse date: YYYYMMDD
         const dateStr = date.toString();
@@ -60,8 +60,36 @@
         return epochNs;
     }
 
+    function to_unixtime_millis(dt) {
+        const { date, time } = dt.get().toObject();
+        // Parse date: YYYYMMDD
+        const dateStr = date.toString();
+        const year = parseInt(dateStr.slice(0, 4));
+        const month = parseInt(dateStr.slice(4, 6)) - 1; // JS months are 0-based
+        const day = parseInt(dateStr.slice(6, 8));
+
+        // Parse time: HHMMSSmmmnnnnnnnnn (always 17 digits)
+        const timeStr = time.toString().padStart(17, "0");
+        const hour = parseInt(timeStr.slice(0, 2));
+        const minute = parseInt(timeStr.slice(2, 4));
+        const second = parseInt(timeStr.slice(4, 6));
+        const millisecond = parseInt(timeStr.slice(6, 9));
+
+        // Construct JS Date (ms precision)
+        const dateObj = Date.UTC(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            millisecond
+        );
+        return dateObj; // Number, ms since epoch
+    }
+
     function fmt(dt, ft) {
-        const i64 = Number(to_unixtime(dt));
+        const i64 = Number(to_unixtime_nanos(dt));
         const milliseconds = Math.floor(i64 / 1000000);
         // Use JS Date's local time handling
         const local_date = new Date(milliseconds);
@@ -187,7 +215,8 @@
     // Expose all functions under window.fastn_datetime
     window.fastn_datetime = {
         now,
-        to_unixtime,
+        to_unixtime_nanos,
+        to_unixtime_millis,
         fmt,
     };
 })();

--- a/datetime.fifthtry.site/js/functions.js
+++ b/datetime.fifthtry.site/js/functions.js
@@ -1,180 +1,193 @@
-function datetime(diff) {
-    const currentDate = new Date();
-    const date = new Date(currentDate.getTime() + diff * 60000);
+// Wrap all functions in an IIFE and expose as window.fastn_datetime
+(function () {
+    function now(diff) {
+        const currentDate = new Date();
+        const date = new Date(currentDate.getTime() + diff * 60000);
 
-    // Date part: YYYYMMDD (always 8 digits)
-    const year = date.getUTCFullYear();
-    const month = (date.getUTCMonth() + 1).toString().padStart(2, "0");
-    const day = date.getUTCDate().toString().padStart(2, "0");
-    const datePart = parseInt(`${year}${month}${day}`);
+        // Date part: YYYYMMDD (always 8 digits)
+        const year = date.getUTCFullYear();
+        const month = (date.getUTCMonth() + 1).toString().padStart(2, "0");
+        const day = date.getUTCDate().toString().padStart(2, "0");
+        const datePart = parseInt(`${year}${month}${day}`);
 
-    // Time part: HHMMSSmmmnnnnnnnnn (always 17 digits, zero-padded)
-    const hours = date.getUTCHours().toString().padStart(2, "0");
-    const minutes = date.getUTCMinutes().toString().padStart(2, "0");
-    const seconds = date.getUTCSeconds().toString().padStart(2, "0");
-    const milliseconds = date.getUTCMilliseconds().toString().padStart(3, "0");
-    // JS Date does not provide nanosecond precision, so pad with zeros
-    const nanoseconds = "000000000";
-    const timeStr = `${hours}${minutes}${seconds}${milliseconds}${nanoseconds}`;
-    // Store as string to preserve leading zeros
+        // Time part: HHMMSSmmmnnnnnnnnn (always 17 digits, zero-padded)
+        const hours = date.getUTCHours().toString().padStart(2, "0");
+        const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+        const seconds = date.getUTCSeconds().toString().padStart(2, "0");
+        const milliseconds = date
+            .getUTCMilliseconds()
+            .toString()
+            .padStart(3, "0");
+        // JS Date does not provide nanosecond precision, so pad with zeros
+        const nanoseconds = "000000000";
+        const timeStr = `${hours}${minutes}${seconds}${milliseconds}${nanoseconds}`;
+        // Store as string to preserve leading zeros
 
-    return new fastn.recordInstanceClass({
-        date: datePart,
-        time: timeStr,
-    });
-}
-
-function constructSingleInt(dt) {
-    const { date, time } = dt.get().toObject();
-    // Parse date: YYYYMMDD
-    const dateStr = date.toString();
-    const year = parseInt(dateStr.slice(0, 4));
-    const month = parseInt(dateStr.slice(4, 6)) - 1; // JS months are 0-based
-    const day = parseInt(dateStr.slice(6, 8));
-
-    // Parse time: HHMMSSmmmnnnnnnnnn (always 17 digits)
-    const timeStr = time.toString().padStart(17, "0");
-    const hour = parseInt(timeStr.slice(0, 2));
-    const minute = parseInt(timeStr.slice(2, 4));
-    const second = parseInt(timeStr.slice(4, 6));
-    const millisecond = parseInt(timeStr.slice(6, 9));
-    const nanosecond = parseInt(timeStr.slice(9, 18));
-
-    // Construct JS Date (ms precision)
-    const dateObj = Date.UTC(
-        year,
-        month,
-        day,
-        hour,
-        minute,
-        second,
-        millisecond
-    );
-    // Convert to ns
-    const epochNs = BigInt(dateObj) * 1_000_000n + BigInt(nanosecond);
-    return epochNs;
-}
-
-function fmt(dt, ft) {
-    const i64 = Number(constructSingleInt(dt));
-    const milliseconds = Math.floor(i64 / 1000000);
-    // Use JS Date's local time handling
-    const local_date = new Date(milliseconds);
-    const format = ft.replaceAll(`"`, "");
-
-    if (format == "datetime") {
-        const weekdays = [
-            "Sunday",
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-        ];
-        const weekday = weekdays[local_date.getDay()];
-
-        const day = local_date.getDate();
-        let dayWithSuffix = day;
-        if (day > 0) {
-            const suffixes = ["th", "st", "nd", "rd"];
-            const relevantDigits =
-                day % 100 > 10 && day % 100 < 14 ? 0 : day % 10;
-            dayWithSuffix = day + (suffixes[relevantDigits] || suffixes[0]);
-        }
-
-        const months = [
-            "January",
-            "February",
-            "March",
-            "April",
-            "May",
-            "June",
-            "July",
-            "August",
-            "September",
-            "October",
-            "November",
-            "December",
-        ];
-        const month = months[local_date.getMonth()];
-
-        // Get year
-        const year = local_date.getFullYear();
-
-        // Get hours in 12-hour format
-        let hours = local_date.getHours();
-        const ampm = hours >= 12 ? "PM" : "AM";
-        hours = hours % 12;
-        hours = hours ? hours : 12; // Convert 0 to 12
-
-        const minutes = local_date.getMinutes().toString().padStart(2, "0");
-
-        const seconds = local_date.getSeconds().toString().padStart(2, "0");
-
-        const ms = local_date.getMilliseconds().toString().padStart(3, "0");
-
-        const formattedDate = `${weekday} ${dayWithSuffix} ${month} ${year} ${hours}:${minutes}:${seconds}:${ms} ${ampm}`;
-
-        return formattedDate;
-    } else if (format == "date") {
-        const weekdays = [
-            "Sunday",
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-        ];
-        const weekday = weekdays[local_date.getDay()];
-
-        const day = local_date.getDate();
-        let dayWithSuffix = day;
-        if (day > 0) {
-            const suffixes = ["th", "st", "nd", "rd"];
-            const relevantDigits =
-                day % 100 > 10 && day % 100 < 14 ? 0 : day % 10;
-            dayWithSuffix = day + (suffixes[relevantDigits] || suffixes[0]);
-        }
-
-        const months = [
-            "January",
-            "February",
-            "March",
-            "April",
-            "May",
-            "June",
-            "July",
-            "August",
-            "September",
-            "October",
-            "November",
-            "December",
-        ];
-        const month = months[local_date.getMonth()];
-
-        // Get year
-        const year = local_date.getFullYear();
-
-        const formattedDate = `${weekday} ${dayWithSuffix} ${month} ${year}`;
-
-        return formattedDate;
-    } else if (format == "time") {
-        let hours = local_date.getHours();
-        const ampm = hours >= 12 ? "PM" : "AM";
-        hours = hours % 12;
-        hours = hours ? hours : 12; // Convert 0 to 12
-
-        const minutes = local_date.getMinutes().toString().padStart(2, "0");
-
-        const seconds = local_date.getSeconds().toString().padStart(2, "0");
-
-        const ms = local_date.getMilliseconds().toString().padStart(3, "0");
-
-        const formatedTime = `${hours}:${minutes}:${seconds}:${ms} ${ampm}`;
-        return formatedTime;
-    } else {
-        return "ft parameter not recognized, please select either: datetime, date or time";
+        return new fastn.recordInstanceClass({
+            date: datePart,
+            time: timeStr,
+        });
     }
-}
+
+    function to_unixtime(dt) {
+        const { date, time } = dt.get().toObject();
+        // Parse date: YYYYMMDD
+        const dateStr = date.toString();
+        const year = parseInt(dateStr.slice(0, 4));
+        const month = parseInt(dateStr.slice(4, 6)) - 1; // JS months are 0-based
+        const day = parseInt(dateStr.slice(6, 8));
+
+        // Parse time: HHMMSSmmmnnnnnnnnn (always 17 digits)
+        const timeStr = time.toString().padStart(17, "0");
+        const hour = parseInt(timeStr.slice(0, 2));
+        const minute = parseInt(timeStr.slice(2, 4));
+        const second = parseInt(timeStr.slice(4, 6));
+        const millisecond = parseInt(timeStr.slice(6, 9));
+        const nanosecond = parseInt(timeStr.slice(9, 18));
+
+        // Construct JS Date (ms precision)
+        const dateObj = Date.UTC(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            millisecond
+        );
+        // Convert to ns
+        const epochNs = BigInt(dateObj) * 1_000_000n + BigInt(nanosecond);
+        return epochNs;
+    }
+
+    function fmt(dt, ft) {
+        const i64 = Number(to_unixtime(dt));
+        const milliseconds = Math.floor(i64 / 1000000);
+        // Use JS Date's local time handling
+        const local_date = new Date(milliseconds);
+        const format = ft.replaceAll(`"`, "");
+
+        if (format == "datetime") {
+            const weekdays = [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+            ];
+            const weekday = weekdays[local_date.getDay()];
+
+            const day = local_date.getDate();
+            let dayWithSuffix = day;
+            if (day > 0) {
+                const suffixes = ["th", "st", "nd", "rd"];
+                const relevantDigits =
+                    day % 100 > 10 && day % 100 < 14 ? 0 : day % 10;
+                dayWithSuffix = day + (suffixes[relevantDigits] || suffixes[0]);
+            }
+
+            const months = [
+                "January",
+                "February",
+                "March",
+                "April",
+                "May",
+                "June",
+                "July",
+                "August",
+                "September",
+                "October",
+                "November",
+                "December",
+            ];
+            const month = months[local_date.getMonth()];
+
+            // Get year
+            const year = local_date.getFullYear();
+
+            // Get hours in 12-hour format
+            let hours = local_date.getHours();
+            const ampm = hours >= 12 ? "PM" : "AM";
+            hours = hours % 12;
+            hours = hours ? hours : 12; // Convert 0 to 12
+
+            const minutes = local_date.getMinutes().toString().padStart(2, "0");
+
+            const seconds = local_date.getSeconds().toString().padStart(2, "0");
+
+            const ms = local_date.getMilliseconds().toString().padStart(3, "0");
+
+            const formattedDate = `${weekday} ${dayWithSuffix} ${month} ${year} ${hours}:${minutes}:${seconds}:${ms} ${ampm}`;
+
+            return formattedDate;
+        } else if (format == "date") {
+            const weekdays = [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+            ];
+            const weekday = weekdays[local_date.getDay()];
+
+            const day = local_date.getDate();
+            let dayWithSuffix = day;
+            if (day > 0) {
+                const suffixes = ["th", "st", "nd", "rd"];
+                const relevantDigits =
+                    day % 100 > 10 && day % 100 < 14 ? 0 : day % 10;
+                dayWithSuffix = day + (suffixes[relevantDigits] || suffixes[0]);
+            }
+
+            const months = [
+                "January",
+                "February",
+                "March",
+                "April",
+                "May",
+                "June",
+                "July",
+                "August",
+                "September",
+                "October",
+                "November",
+                "December",
+            ];
+            const month = months[local_date.getMonth()];
+
+            // Get year
+            const year = local_date.getFullYear();
+
+            const formattedDate = `${weekday} ${dayWithSuffix} ${month} ${year}`;
+
+            return formattedDate;
+        } else if (format == "time") {
+            let hours = local_date.getHours();
+            const ampm = hours >= 12 ? "PM" : "AM";
+            hours = hours % 12;
+            hours = hours ? hours : 12; // Convert 0 to 12
+
+            const minutes = local_date.getMinutes().toString().padStart(2, "0");
+
+            const seconds = local_date.getSeconds().toString().padStart(2, "0");
+
+            const ms = local_date.getMilliseconds().toString().padStart(3, "0");
+
+            const formatedTime = `${hours}:${minutes}:${seconds}:${ms} ${ampm}`;
+            return formatedTime;
+        } else {
+            return "ft parameter not recognized, please select either: datetime, date or time";
+        }
+    }
+
+    // Expose all functions under window.fastn_datetime
+    window.fastn_datetime = {
+        now,
+        to_unixtime,
+        fmt,
+    };
+})();

--- a/datetime.fifthtry.site/js/functions.js
+++ b/datetime.fifthtry.site/js/functions.js
@@ -29,7 +29,7 @@
         });
     }
 
-    function to_unixtime_nanos(dt) {
+    function to_timestamp_nanos(dt) {
         const { date, time } = dt.get().toObject();
         // Parse date: YYYYMMDD
         const dateStr = date.toString();
@@ -60,7 +60,7 @@
         return epochNs;
     }
 
-    function to_unixtime_millis(dt) {
+    function to_timestamp_millis(dt) {
         const { date, time } = dt.get().toObject();
         // Parse date: YYYYMMDD
         const dateStr = date.toString();
@@ -89,7 +89,7 @@
     }
 
     function fmt(dt, ft) {
-        const i64 = Number(to_unixtime_nanos(dt));
+        const i64 = Number(to_timestamp_nanos(dt));
         const milliseconds = Math.floor(i64 / 1000000);
         // Use JS Date's local time handling
         const local_date = new Date(milliseconds);
@@ -215,8 +215,8 @@
     // Expose all functions under window.fastn_datetime
     window.fastn_datetime = {
         now,
-        to_unixtime_nanos,
-        to_unixtime_millis,
+        to_timestamp_nanos,
+        to_timestamp_millis,
         fmt,
     };
 })();


### PR DESCRIPTION
Making changes such that the `$now()` function returns two integers instead of one, and adding a new function `$combine()` that will combine the two integers and return one BigInt integer in unix epoch. Now the datetime package more closely mimics the Rust Chrono package. 



https://github.com/user-attachments/assets/a2ee468f-08ba-414c-afaa-5ec67827d932

